### PR TITLE
Skip pre-commit hook in CI checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           extra_args: --all-files --show-diff-on-failure
         env:
-          SKIP: lint-go-code
+          SKIP: lint-go-code,no-commit-to-branch
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This hook isn't of much use in CI because the `main` branch is protected anyway and the hook would always fail when run on `main`.
