### PR TITLE
Remove unnecessary footer from release notes template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,6 @@ changelog:
       - '^chore:'
       - '^build:'
 
-release:
-  footer: |
-    ### Summary
-    **Full Changelog**: https://github.com/makkes/garage/compare/{{ .PreviousTag }}...{{ .Tag }}
-
 builds:
   - id: garage
     binary: garage


### PR DESCRIPTION
The link is generated by the github-native implementation already.
