### PR TITLE
More lenient Content-Type handling

### DIFF
--- a/pkg/registry/blob_session.go
+++ b/pkg/registry/blob_session.go
@@ -58,7 +58,7 @@ func (r Registry) handleBlobGet(c *fiber.Ctx) error {
 
 func (r Registry) handleBlobPatch(c *fiber.Ctx) error {
 	ct := c.Request().Header.ContentType()
-	if string(ct) != "application/octet-stream" {
+	if len(ct) != 0 && string(ct) != "application/octet-stream" {
 		r.log.V(8).Info("POST request with invalid content type", "content-type", ct)
 		return c.Status(fiber.StatusBadRequest).
 			SendString(fmt.Sprintf("content-type must be 'application/octet-stream' but is %q", string(ct)))


### PR DESCRIPTION
When a client doesn't send a 'Content-Type' header Garage now assumes `application/octet-stream`. It will still fail when another Content-Type is set.
