### PR TITLE
Support legacy Docker-Content-Digest header

### DIFF
--- a/cmd/garage/main.go
+++ b/cmd/garage/main.go
@@ -50,6 +50,7 @@ func main() {
 	}
 
 	r, err := registry.New(
+		registry.WithFeatures(cfg.Features),
 		registry.WithFileStorage(s),
 		registry.WithMiddleware(logger.New()),
 		registry.WithLogger(log.WithName("registry")),

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/makkes/garage/pkg/features"
 )
 
 const (
@@ -23,8 +25,9 @@ const (
 )
 
 type Config struct {
-	V  *viper.Viper
-	FS *pflag.FlagSet
+	V        *viper.Viper
+	FS       *pflag.FlagSet
+	Features features.Features
 }
 
 func InitViper() (Config, error) {
@@ -54,6 +57,9 @@ func InitViper() (Config, error) {
 	cfg.FS.String(KeyTLSCertFile, cfg.V.GetString(KeyTLSCertFile), "Certificate file for serving HTTPS")
 	cfg.FS.String(KeyTLSKeyFile, cfg.V.GetString(KeyTLSKeyFile), "Key file for serving HTTPS")
 	cfg.FS.BoolP(KeyHelp, "h", false, "Show this help")
+
+	cfg.Features = features.Features{}
+	cfg.Features.BindFlags(cfg.FS)
 
 	if err := cfg.FS.Parse(os.Args[1:]); err != nil {
 		return cfg, fmt.Errorf("failed parsing command-line flags: %w", err)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,36 @@
+package features
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	SendLegacyDigestHeader = "SendLegacyDigestHeader"
+)
+
+var knownFeatures = []string{
+	SendLegacyDigestHeader,
+}
+
+type Features struct {
+	Flag *[]string
+}
+
+func (f *Features) BindFlags(fs *pflag.FlagSet) {
+	f.Flag = fs.StringSlice("feature-gates", nil, fmt.Sprintf("A set of feature gate names to enable. Features are:\n%s", strings.Join(knownFeatures, "\n")))
+}
+
+func (f Features) Enabled(feat string) bool {
+	if f.Flag == nil {
+		return false
+	}
+	for _, flag := range *f.Flag {
+		if flag == feat {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/registry/blob_session.go
+++ b/pkg/registry/blob_session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
+	"github.com/makkes/garage/pkg/features"
 	"github.com/makkes/garage/pkg/storage"
 	"github.com/makkes/garage/pkg/types"
 )
@@ -140,6 +141,9 @@ func (r Registry) handleBlobPut(c *fiber.Ctx) error {
 	}
 
 	c.Set(fiber.HeaderLocation, fmt.Sprintf("/v2/%s/%s/blobs/%s", bid.Namespace, bid.Repo, resDig))
+	if r.features.Enabled(features.SendLegacyDigestHeader) {
+		c.Set("Docker-Content-Digest", resDig.String())
+	}
 
 	return c.SendStatus(fiber.StatusCreated)
 }

--- a/pkg/registry/opts.go
+++ b/pkg/registry/opts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"go.uber.org/zap"
 
+	"github.com/makkes/garage/pkg/features"
 	"github.com/makkes/garage/pkg/storage"
 )
 
@@ -36,6 +37,13 @@ func (r *Registry) applyDefaults() error {
 	}
 
 	return nil
+}
+
+func WithFeatures(f features.Features) Opt {
+	return func(r *Registry) error {
+		r.features = f
+		return nil
+	}
 }
 
 func WithMaxManifestBytes(b int64) Opt {

--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/makkes/garage/pkg/features"
 	"github.com/makkes/garage/pkg/types"
 )
 
@@ -97,6 +98,9 @@ func (r Registry) handleManifestPush(c *fiber.Ctx) error {
 	}
 
 	c.Set(fiber.HeaderLocation, fmt.Sprintf("/v2/%s/%s/manifests/%s", mid.Namespace, mid.Repo, mid.Ref()))
+	if r.features.Enabled(features.SendLegacyDigestHeader) {
+		c.Set("Docker-Content-Digest", mid.Digest.String())
+	}
 
 	return c.SendStatus(fiber.StatusCreated)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
+	"github.com/makkes/garage/pkg/features"
 	"github.com/makkes/garage/pkg/storage"
 	"github.com/makkes/garage/pkg/types"
 )
@@ -43,6 +44,7 @@ type Registry struct {
 	maxManifestBytes int64
 	store            storage.Storage
 	uploadSessions   map[string]string
+	features         features.Features
 }
 
 func New(opts ...Opt) (Registry, error) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -12,8 +12,35 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/makkes/garage/pkg/features"
 	"github.com/makkes/garage/pkg/registry"
 )
+
+func TestPushManifestWithLegacyHeader(t *testing.T) {
+	g := NewWithT(t)
+
+	r, _ := registry.New(
+		registry.WithMemStorage(),
+		registry.WithFeatures(features.Features{
+			Flag: &[]string{
+				features.SendLegacyDigestHeader,
+			},
+		}),
+	)
+
+	mt := "application/vnd.oci.image.manifest.v1+json"
+	manifest := []byte(`{"mediaType":"` + mt + `"}`)
+
+	req := httptest.NewRequest(http.MethodPut, "/v2/ns/repo/manifests/new-ref", bytes.NewReader(manifest))
+	req.Header.Add("Content-Type", mt)
+
+	resp, err := r.Test(req)
+
+	g.Expect(err).NotTo(HaveOccurred(), "test request failed unexpectedly")
+	g.Expect(resp.StatusCode).To(Equal(http.StatusCreated), "received unexpected status code")
+
+	g.Expect(resp.Header["Docker-Content-Digest"]).To(Equal([]string{"sha256:0a1b17bf6d39f56897a7e8a056d930cf2bde38841a187aeb083d7487e2224573"}))
+}
 
 func TestPushAndPullManifest(t *testing.T) {
 	g := NewWithT(t)
@@ -36,6 +63,7 @@ func TestPushAndPullManifest(t *testing.T) {
 	expectedLoc, err := url.Parse("/v2/ns/repo/manifests/new-ref")
 	g.Expect(err).NotTo(HaveOccurred(), "failed parsing URL")
 	g.Expect(resp.Location()).To(Equal(expectedLoc), "unexpected location header")
+	g.Expect(resp.Header["Docker-Content-Digest"]).To(BeEmpty())
 
 	req = httptest.NewRequest(http.MethodGet, expectedLoc.String(), nil)
 


### PR DESCRIPTION
Many registry clients require the header to be sent so this feature can be enabled via the 'SendLegacyDigestHeader' feature flag. The default is still to not send this header because it's optional according to the spec.
